### PR TITLE
Error when doing gem install

### DIFF
--- a/ruby/lib/message.rb
+++ b/ruby/lib/message.rb
@@ -58,7 +58,7 @@ module Karait
       
       return if meta.fetch('expire', -1.0) == -1.0
       
-      if current_time - meta.fetch('timestamp', 0.0) > meta.fetch('expire', -1.0):
+      if current_time - meta.fetch('timestamp', 0.0) > meta.fetch('expire', -1.0)
         @expired = true
       end
     end


### PR DESCRIPTION
There is a colon (probably from writing a python version :p) that is causing an error to be thrown when you try to install the gem.
